### PR TITLE
Capitalizing pronouns at beginning of sentences, mainly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 Changes made in this fork:
 
 Pronoun dresser:
-Capitalization for subjective and possessive determiner pronouns at the beginning of a sentence, using {Sub} and {Pod}
-Better grammar when using a name in place of all pronouns
+- Capitalization for subjective and possessive determiner pronouns at the beginning of a sentence, using {Sub} and {Pod}
+- Better grammar when using a name in place of all pronouns
+- Better formatting on mobile devices
 
 PIL tool:
-Beginning of sentence detection to implement {Sub} and {Pod}
+- Beginning of sentence detection to implement {Sub} and {Pod}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# asteine8.github.io
+Changes made in this fork:
+
+Pronoun dresser:
+Capitalization for subjective and possessive determiner pronouns at the beginning of a sentence, using {Sub} and {Pod}
+Better grammar when using a name in place of all pronouns
+
+PIL tool:
+Beginning of sentence detection to implement {Sub} and {Pod}

--- a/projects/pronoun-dressing-room/dressing-room/index.html
+++ b/projects/pronoun-dressing-room/dressing-room/index.html
@@ -79,7 +79,7 @@
             <div class="textbox">
                 <div class="textbox_textalignmentdiv">
                     <p></p>
-                    <textarea>Oh, did you hear about {name}’s newest creation? {sub} made a beautiful painting of a campground that {pod} family took {obj} to back when {sub} was a child. {name} is sooo talented, I wish I was {obj}.</textarea>
+                    <textarea>Oh, did you hear about {name}’s newest creation? {Sub} made a beautiful painting of a campground that {pod} family took {obj} to back when {sub} was a child. {name} is sooo talented, I wish I was {obj}.</textarea>
                 </div>
 
                 <div class="textbox_buttonbox">
@@ -107,7 +107,7 @@
             <div class="textbox">
                 <div class="textbox_textalignmentdiv">
                     <p></p>
-                    <textarea>Hey {name}, {name} is one of the cutest names ever, I just adored every {name} I’ve ever met. What I would say to you is go for it and try out, but also don’t feel rushed and pressured to figure it out now. I am assuming you are a teen, sorry if Im wrong, but it’s ruff to figure who you are, I see some teens going as if wondering for a few months is a live or die in a rush kind a thing, but everyone has their own pace, take your time, not saying it has to wait for ever but just, take your time. I wish you all the luck and love 💕</textarea>
+                    <textarea>Hey {name}, {name} is one of the cutest names ever, I just adored every {name} I’ve ever met. What I would say to you is go for it and try out, but also don’t feel rushed and pressured to figure it out now. I am assuming you are a teen, sorry if I'm wrong, but it’s ruff to figure who you are, I see some teens going as if wondering for a few months is a live or die in a rush kind a thing, but everyone has their own pace, take your time, not saying it has to wait for ever but just, take your time. I wish you all the luck and love 💕</textarea>
                 </div>
 
                 <div class="textbox_buttonbox">
@@ -121,7 +121,7 @@
             <div class="textbox">
                 <div class="textbox_textalignmentdiv">
                     <p></p>
-                    <textarea>{name} is just in the other room changing.<br><br>No, I don’t think {sub} forgot to bring the paintings. So the other day during the heist, I saw {obj} slip the paintings into that bag of {pop}. I know {name} brought it into the car, and Zoe told me {sub} saw the same bag in {pod} car. Why don’t we go ask {name} if {sub} has the paintings to be sure?<br><br>Well, why don’t you trust {name}, I trust {obj}. I doubt {sub} would ever keep that painting for {ref}, {name} just isn’t that kind of person.<br><br>Oh, hi {name}, we were just talking about the paintings from Thursday. Nat here was wondering if you had them in your car Wonderful!<br><br>See Nat, we can trust {obj}. Now go and get those bloody painting so we can meet the fence.</textarea>
+                    <textarea>{name} is just in the other room changing.<br><br>No, I don’t think {sub} forgot to bring the paintings. So the other day during the heist, I saw {obj} slip the paintings into that bag of {pop}. I know {name} brought it into the car, and Zoe told me {sub} saw the same bag in {pod} car. Why don’t we go ask {name} if {sub} has the paintings to be sure?<br><br>Well, why don’t you trust {name}, I trust {obj}. I doubt {sub} would ever keep that painting for {ref}, {name} just isn’t that kind of person.<br><br>Oh, hi {name}, we were just talking about the paintings from Thursday. Nat here was wondering if you had them in your car. Wonderful!<br><br>See Nat, we can trust {obj}. Now go and get those bloody painting so we can meet the fence.</textarea>
                 </div>
 
                 <div class="textbox_buttonbox">
@@ -135,7 +135,7 @@
             <div class="textbox">
                 <div class="textbox_textalignmentdiv">
                     <p></p>
-                    <textarea>Did you hear about what {name} did last week? {sub} went hiking up the nearby mountains and carried a keyboard up with {obj}. Like, omg, {sub} carried an electric keyboard on {pod} back like 15 miles up the face of a cliff, camped near the top, and spent the whole bloody next day playing the Tetris theme to the wind and clouds. I just hope that the keyboard is actually {pop}, that thing looks pretty banged up from being carried that far.</textarea>
+                    <textarea>Did you hear about what {name} did last week? {Sub} went hiking up the nearby mountains and carried a keyboard up with {obj}. Like, omg, {sub} carried an electric keyboard on {pod} back like 15 miles up the face of a cliff, camped near the top, and spent the whole bloody next day playing the Tetris theme to the wind and clouds. I just hope that the keyboard is actually {pop}, that thing looks pretty banged up from being carried that far.</textarea>
                 </div>
 
                 <div class="textbox_buttonbox">
@@ -149,7 +149,7 @@
             <div class="textbox">
                 <div class="textbox_textalignmentdiv">
                     <p></p>
-                    <textarea>Hey, it's {name}! {sub}'s so cute and smart! {name} is real good with computers too, {sub} helped me out recently. I hope I'll be meeting {obj} again soon, I love to hang out with {obj}!</textarea>
+                    <textarea>Hey, it's {name}! {Sub}'s so cute and smart! {name} is real good with computers too, {sub} helped me out recently. I hope I'll be meeting {obj} again soon, I love to hang out with {obj}!</textarea>
                 </div>
 
                 <div class="textbox_buttonbox">

--- a/projects/pronoun-dressing-room/dressing-room/script.js
+++ b/projects/pronoun-dressing-room/dressing-room/script.js
@@ -145,3 +145,7 @@ function applyPronounsToAllTextboxes() {
         applyPronounsToTextbox(textboxes[b]);
     }
 }
+
+function capitalizeFirstLetter(string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+}

--- a/projects/pronoun-dressing-room/dressing-room/script.js
+++ b/projects/pronoun-dressing-room/dressing-room/script.js
@@ -105,6 +105,8 @@ function applyPronounsAndNameToText(text) {
             text = text.replace(/{pod}/g, pronouns[0][2]);
             text = text.replace(/{pop}/g, pronouns[0][3]);
             text = text.replace(/{ref}/g, pronouns[0][4]);
+            text = text.replace(/{Sub}/g, capitalizeFirstLetter(pronouns[0][0]));
+            text = text.replace(/{Pod}/g, capitalizeFirstLetter(pronouns[0][2]));
 
             text = text.replace(/{name}/g, name);
         }
@@ -117,10 +119,10 @@ function applyPronounsAndNameToText(text) {
 
     // Not using Pronouns, just slap in the name over everything
     else {
-        text = text.replace(/{sub}/g, name);
+        text = text.replace(/{sub}/gi, name);
         text = text.replace(/{obj}/g, name);
-        text = text.replace(/{pod}/g, name);
-        text = text.replace(/{pop}/g, name);
+        text = text.replace(/{pod}/gi, name+"'s");
+        text = text.replace(/{pop}/g, name+"'s");
         text = text.replace(/{ref}/g, name);
 
         text = text.replace(/{name}/g, name);

--- a/projects/pronoun-dressing-room/dressing-room/script.js
+++ b/projects/pronoun-dressing-room/dressing-room/script.js
@@ -5,6 +5,15 @@ let usingPronouns = true;
 
 // Nice initialization function for lazy people
 function onpageload() {
+    //formatting for mobile devices
+    if (window.innerHeight>window.innerWidth) {
+        document.getElementById("sidebar").style.position="static";
+        document.getElementById("sidebar").style.width="100%";
+        document.getElementById("sidebar").style.maxWidth="90%";
+        document.getElementById("textholder").style.width="90%";
+        document.getElementById("spacer").style.minHeight=0;
+    }
+    
     // Lets use pronouns by default
     document.getElementById("yespronounsradio").checked = true;
 

--- a/projects/pronoun-dressing-room/pil-tool/parser.js
+++ b/projects/pronoun-dressing-room/pil-tool/parser.js
@@ -77,7 +77,6 @@ function generateTaggedText() {
                 else if (taggedwords[w+1][1].match(/NN|RB/i)) {
                     // Check the PRP matches expected pronoun
                     if (taggedwords[w][0].toLowerCase().match(pronounSet[2])) {
-                      if (taggedwords[w][0].toLowerCase().match(pronounSet[2])) {
                         if (w==0||taggedwords[w-1][1]==".") {
                             taggedwords[w][0] = taggedwords[w][0].replace(subregex, "{Pod}");
                         } else {
@@ -91,7 +90,6 @@ function generateTaggedText() {
             if (w < taggedwords.length-2) {
                 if (taggedwords[w+1][1].match(/JJ/i) && taggedwords[w+2][1].match(/NN/i)) {
                     if (taggedwords[w][0].toLowerCase().match(pronounSet[2])) {
-                      if (taggedwords[w][0].toLowerCase().match(pronounSet[2])) {
                         if (w==0||taggedwords[w-1][1]==".") {
                             taggedwords[w][0] = taggedwords[w][0].replace(subregex, "{Pod}");
                         } else {

--- a/projects/pronoun-dressing-room/pil-tool/parser.js
+++ b/projects/pronoun-dressing-room/pil-tool/parser.js
@@ -47,7 +47,11 @@ function generateTaggedText() {
 
         // Check for Subjective PRP
         if (taggedwords[w][0].toLowerCase().match(subregex) && taggedwords[w][1].match(/PRP|NN/i)) {
-            taggedwords[w][0] = taggedwords[w][0].replace(subregex, "{sub}");
+            if (w==0||taggedwords[w-1][1]==".") {
+                taggedwords[w][0] = taggedwords[w][0].replace(subregex, "{Sub}");
+            } else {
+                taggedwords[w][0] = taggedwords[w][0].replace(subregex, "{sub}");
+            }
         }
 
         // Check if personal pronoun
@@ -73,7 +77,12 @@ function generateTaggedText() {
                 else if (taggedwords[w+1][1].match(/NN|RB/i)) {
                     // Check the PRP matches expected pronoun
                     if (taggedwords[w][0].toLowerCase().match(pronounSet[2])) {
-                        taggedwords[w][0] = "{pod}";
+                      if (taggedwords[w][0].toLowerCase().match(pronounSet[2])) {
+                        if (w==0||taggedwords[w-1][1]==".") {
+                            taggedwords[w][0] = taggedwords[w][0].replace(subregex, "{Pod}");
+                        } else {
+                            taggedwords[w][0] = taggedwords[w][0].replace(subregex, "{pod}");
+                        }
                     }
                 }
             }
@@ -82,7 +91,12 @@ function generateTaggedText() {
             if (w < taggedwords.length-2) {
                 if (taggedwords[w+1][1].match(/JJ/i) && taggedwords[w+2][1].match(/NN/i)) {
                     if (taggedwords[w][0].toLowerCase().match(pronounSet[2])) {
-                        taggedwords[w][0] = "{pod}";
+                      if (taggedwords[w][0].toLowerCase().match(pronounSet[2])) {
+                        if (w==0||taggedwords[w-1][1]==".") {
+                            taggedwords[w][0] = taggedwords[w][0].replace(subregex, "{Pod}");
+                        } else {
+                            taggedwords[w][0] = taggedwords[w][0].replace(subregex, "{pod}");
+                        }
                     }
                 }
             }

--- a/projects/pronoun-dressing-room/pil-tool/parser.js
+++ b/projects/pronoun-dressing-room/pil-tool/parser.js
@@ -47,11 +47,7 @@ function generateTaggedText() {
 
         // Check for Subjective PRP
         if (taggedwords[w][0].toLowerCase().match(subregex) && taggedwords[w][1].match(/PRP|NN/i)) {
-            if (w==0||taggedwords[w-1][1]==".") {
-                taggedwords[w][0] = taggedwords[w][0].replace(subregex, "{Sub}");
-            } else {
-                taggedwords[w][0] = taggedwords[w][0].replace(subregex, "{sub}");
-            }
+            taggedwords[w][0] = taggedwords[w][0].replace(subregex, w==0||taggedwords[w-1][1]=="."?"{Sub}":"{sub}");
         }
 
         // Check if personal pronoun
@@ -77,11 +73,7 @@ function generateTaggedText() {
                 else if (taggedwords[w+1][1].match(/NN|RB/i)) {
                     // Check the PRP matches expected pronoun
                     if (taggedwords[w][0].toLowerCase().match(pronounSet[2])) {
-                        if (w==0||taggedwords[w-1][1]==".") {
-                            taggedwords[w][0] = "{Pod}";
-                        } else {
-                            taggedwords[w][0] = "{pod}";
-                        }
+                        taggedwords[w][0] = w==0||taggedwords[w-1][1]=="."?"{Pod}":"{pod}";
                     }
                 }
             }
@@ -90,11 +82,7 @@ function generateTaggedText() {
             if (w < taggedwords.length-2) {
                 if (taggedwords[w+1][1].match(/JJ/i) && taggedwords[w+2][1].match(/NN/i)) {
                     if (taggedwords[w][0].toLowerCase().match(pronounSet[2])) {
-                        if (w==0||taggedwords[w-1][1]==".") {
-                            taggedwords[w][0] = "{Pod}";
-                        } else {
-                            taggedwords[w][0] = "{pod}";
-                        }
+                        taggedwords[w][0] = w==0||taggedwords[w-1][1]=="."?"{Pod}":"{pod}";
                     }
                 }
             }

--- a/projects/pronoun-dressing-room/pil-tool/parser.js
+++ b/projects/pronoun-dressing-room/pil-tool/parser.js
@@ -78,9 +78,9 @@ function generateTaggedText() {
                     // Check the PRP matches expected pronoun
                     if (taggedwords[w][0].toLowerCase().match(pronounSet[2])) {
                         if (w==0||taggedwords[w-1][1]==".") {
-                            taggedwords[w][0] = taggedwords[w][0].replace(subregex, "{Pod}");
+                            taggedwords[w][0] = "{Pod}";
                         } else {
-                            taggedwords[w][0] = taggedwords[w][0].replace(subregex, "{pod}");
+                            taggedwords[w][0] = "{pod}";
                         }
                     }
                 }
@@ -91,9 +91,9 @@ function generateTaggedText() {
                 if (taggedwords[w+1][1].match(/JJ/i) && taggedwords[w+2][1].match(/NN/i)) {
                     if (taggedwords[w][0].toLowerCase().match(pronounSet[2])) {
                         if (w==0||taggedwords[w-1][1]==".") {
-                            taggedwords[w][0] = taggedwords[w][0].replace(subregex, "{Pod}");
+                            taggedwords[w][0] = "{Pod}";
                         } else {
-                            taggedwords[w][0] = taggedwords[w][0].replace(subregex, "{pod}");
+                            taggedwords[w][0] = "{pod}";
                         }
                     }
                 }


### PR DESCRIPTION
Hello hi
I found this pronoun tool on Reddit and wanted to improve it so I made a fork. I actually have never used a pull request before but here it is.
This fork capitalizes {sub} and {pod} pronouns at the beginning of sentences. It makes the PIL tool use {Sub} and {Pod} if they are at the beginning of a sentence, and the dressing room capitalize {Sub} and {Pod}. It also adds "'s" to the end of a name if not using pronouns and if "'s" would be gramatically sensible.

Edit: It now changes the formatting when the window is taller than it is wide, to fit better on mobile devices.